### PR TITLE
bump base image versions to fix glibc version mismatch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM rust:1.69-slim as builder
+FROM rust:1.70-bookworm as builder
 WORKDIR /usr/src/haunted-coop
 COPY . .
 RUN apt update && apt install -yq pkg-config libssl-dev && cargo test && cargo install --path . --locked
 
-FROM rust:1.65-slim-buster
+FROM rust:1.70-slim-bookworm
 COPY --from=builder /usr/local/cargo/bin/haunted-coop /usr/local/bin/haunted-coop
 EXPOSE 1996
 ENTRYPOINT ["haunted-coop"]


### PR DESCRIPTION
The haunted co-op server fails to start with ```haunted-coop: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.29' not found (required by haunted-coop)` ```
I did some research and found this is caused by an old version of glibc in the buster base image. 
This PR bumps the base image to bookworm (the current debian version) and i'm able to run haunted co-op locally with this change.